### PR TITLE
Update to be compatible with NumPy v1.20+

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -16,7 +16,7 @@ def jacobian2(function, x):
     """
     x = np.asarray(x)
     assert x.ndim == 1, "x must be a vector"
-    x_ad = np.empty(x.shape, dtype=np.object)
+    x_ad = np.empty(x.shape, dtype=object)
     for i in range(x.size):
         der = np.zeros(x.size)
         der[i] = 1


### PR DESCRIPTION
@vincekurtz Any chance this work for ya?

With this update, I can run `simulate.py` on Ubuntu 22.04 using
```
pip install drake==1.15.0 jupyterlab ipywidgets matplotlib tk
```